### PR TITLE
Fix holiday comparisons for countdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,8 +34,8 @@
 
     <script>
         // Target date for the end of the school year (ISO format)
-        const startDate = new Date('2024-08-19');
-        const endDate = new Date('2025-06-20');
+        const startDate = toDate('2024-08-19');
+        const endDate = toDate('2025-06-20');
 
         /*
          * Define holiday ranges and individual holiday dates.  Each holiday range
@@ -137,6 +137,14 @@
             return d >= start && d <= end;
         }
 
+        // Convert a Date to a YYYY-MM-DD string in the local timezone
+        function toLocalISODate(date) {
+            const year = date.getFullYear();
+            const month = String(date.getMonth() + 1).padStart(2, '0');
+            const day = String(date.getDate()).padStart(2, '0');
+            return `${year}-${month}-${day}`;
+        }
+
         // Determine whether a given date (object) is a holiday
         function isHoliday(d) {
             // Check ranges
@@ -146,7 +154,7 @@
                 }
             }
             // Check individual dates
-            const iso = d.toISOString().slice(0, 10);
+            const iso = toLocalISODate(d);
             return holidayDates.includes(iso);
         }
 


### PR DESCRIPTION
## Summary
- ensure the countdown start and end dates are treated consistently with other comparisons
- add a helper to compare holiday dates in the local timezone so individual holidays are detected

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4c2b05fc0832283c342c0b8fc763b