### PR TITLE
Fix countdown after final school day

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,8 +34,8 @@
 
     <script>
         // Target date for the end of the school year (ISO format)
-        const startDate = new Date('2024-08-19');
-        const endDate = new Date('2025-06-20');
+        const startDate = toDate('2024-08-19');
+        const endDate = toDate('2025-06-20');
 
         /*
          * Define holiday ranges and individual holiday dates.  Each holiday range
@@ -137,6 +137,14 @@
             return d >= start && d <= end;
         }
 
+        // Convert a Date to a YYYY-MM-DD string in the local timezone
+        function toLocalISODate(date) {
+            const year = date.getFullYear();
+            const month = String(date.getMonth() + 1).padStart(2, '0');
+            const day = String(date.getDate()).padStart(2, '0');
+            return `${year}-${month}-${day}`;
+        }
+
         // Determine whether a given date (object) is a holiday
         function isHoliday(d) {
             // Check ranges
@@ -146,7 +154,7 @@
                 }
             }
             // Check individual dates
-            const iso = d.toISOString().slice(0, 10);
+            const iso = toLocalISODate(d);
             return holidayDates.includes(iso);
         }
 
@@ -159,7 +167,8 @@
             let count = 0;
             // Ensure we do not count days before the official start date
             let current = new Date(Math.max(from.getTime(), startDate.getTime()));
-            while (current <= to) {
+            const inclusiveEnd = new Date(to.getFullYear(), to.getMonth(), to.getDate(), 23, 59, 59, 999);
+            while (current <= inclusiveEnd) {
                 const dayOfWeek = current.getDay();
                 // Check if current day is a weekday (Mon–Fri)
                 const isWeekday = dayOfWeek >= 1 && dayOfWeek <= 5;
@@ -196,33 +205,41 @@
         // Update the displayed number of school days remaining
         function updateSchoolDays() {
             const now = new Date();
-            // If we are before the school start date, show the full total
-            if (now < startDate) {
-                const fullCount = countSchoolDays(startDate, endDate);
-                document.getElementById('countdown').textContent = fullCount + ' school days left';
-                return;
-            }
-            // If we’re past the end date, show zero and a message
-            if (now > endDate) {
-                document.getElementById('countdown').textContent = 'School is out!';
-                return;
-            }
-            const daysLeft = countSchoolDays(now, endDate);
-            // Calculate passed days based on total school days and days left
             const totalSchoolDays = countSchoolDays(startDate, endDate);
-            const passedDays = totalSchoolDays - daysLeft;
-            document.getElementById('countdown').textContent = daysLeft + ' school day' + (daysLeft === 1 ? '' : 's') + ' left';
-            document.getElementById('passed').textContent = passedDays + ' school day' + (passedDays === 1 ? '' : 's') + ' completed';
+            const daysLeft = countSchoolDays(now, endDate);
 
-            // Update next holiday information
-            const nextHoliday = getNextHoliday(now);
-            if (nextHoliday) {
-                const holLen = countHolidayWeekdays(nextHoliday);
-                const startDateObj = toDate(nextHoliday.start);
-                const options = { year: 'numeric', month: 'short', day: 'numeric' };
-                const startStr = startDateObj.toLocaleDateString(undefined, options);
-                document.getElementById('next-holiday').textContent =
-                    'Next holiday: ' + nextHoliday.name + ' (' + holLen + ' school day' + (holLen === 1 ? '' : 's') + ') starting ' + startStr;
+            let countdownText = '';
+            let passedText = '';
+
+            const totalLabel = totalSchoolDays + ' school day' + (totalSchoolDays === 1 ? '' : 's');
+
+            if (now < startDate) {
+                countdownText = totalLabel + ' left';
+                passedText = '0 school days completed';
+            } else if (daysLeft <= 0) {
+                countdownText = 'School is out!';
+                passedText = totalLabel + ' completed';
+            } else {
+                const passedDays = totalSchoolDays - daysLeft;
+                countdownText = daysLeft + ' school day' + (daysLeft === 1 ? '' : 's') + ' left';
+                passedText = passedDays + ' school day' + (passedDays === 1 ? '' : 's') + ' completed';
+            }
+
+            document.getElementById('countdown').textContent = countdownText;
+            document.getElementById('passed').textContent = passedText;
+
+            if (daysLeft > 0) {
+                const nextHoliday = getNextHoliday(now);
+                if (nextHoliday) {
+                    const holLen = countHolidayWeekdays(nextHoliday);
+                    const startDateObj = toDate(nextHoliday.start);
+                    const options = { year: 'numeric', month: 'short', day: 'numeric' };
+                    const startStr = startDateObj.toLocaleDateString(undefined, options);
+                    document.getElementById('next-holiday').textContent =
+                        'Next holiday: ' + nextHoliday.name + ' (' + holLen + ' school day' + (holLen === 1 ? '' : 's') + ') starting ' + startStr;
+                } else {
+                    document.getElementById('next-holiday').textContent = 'No more holidays before the end of term.';
+                }
             } else {
                 document.getElementById('next-holiday').textContent = 'No more holidays before the end of term.';
             }


### PR DESCRIPTION
## Summary
- treat the final school day as running through its closing time by counting until the end of day
- update the countdown logic to rely on the recomputed school-day total so it keeps showing the last day until it finishes
- ensure the "passed" and holiday panels stay up to date before term starts or after it ends

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4c2b05fc0832283c342c0b8fc763b